### PR TITLE
Simplify DS interface, removing methods unused in TI app

### DIFF
--- a/pkg/sdk/datasource.go
+++ b/pkg/sdk/datasource.go
@@ -15,13 +15,10 @@ type DataSourceFactory func(id models.DataSourceID, owner, name string) (ds Data
 
 // DataSource defines a GeCo data source, which is instantiated by a DataSourceFactory.
 type DataSource interface {
-	FromModel(model *DataSourceModel)
 	GetModel() *DataSourceModel
 	SetID(id models.DataSourceID)
 	GetID() models.DataSourceID
 	GetOwner() string
-	GetData(query string) ([]string, [][]float64)
-	LoadData(columns []string, data interface{}) error
 	Data() map[string]interface{}
 	// Config configures the data source. It must be called after DataSourceFactory.
 	Config(logger logrus.FieldLogger, config map[string]interface{}) error


### PR DESCRIPTION
Removed the following from the `sdk.DataSource` interface:

`FromModel` not needed as datasources are created from their factory
`LoadData` is not relevant for a generic data source
`GetData` is a duplicate of Query, to further integrate, will add in the Future a `GetRows(params interface{})` to replace it. 
